### PR TITLE
fix: replace "config:base" with "config:recommended"

### DIFF
--- a/kong-frontend-config.json
+++ b/kong-frontend-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":semanticCommits",
     ":automergeRequireAllStatusChecks",
     ":automergePatch",
@@ -50,7 +50,7 @@
       "minimumReleaseAge": "2 hours",
       "schedule": [
         "every weekday"
-      ],
+      ]
     }
   ]
 }


### PR DESCRIPTION
Ref: https://github.com/renovatebot/renovate/issues/23326

Renovate renamed "config:base" to "config:recommended" and this silently broke.