### PR TITLE
feat: disable updating branches outside of schedule

### DIFF
--- a/kong-frontend-config.json
+++ b/kong-frontend-config.json
@@ -23,6 +23,7 @@
     "every weekday"
   ],
   "minimumReleaseAge": "14 days",
+  "updateNotScheduled": false,
   "packageRules": [
     {
       "automerge": true,


### PR DESCRIPTION
Same logic from https://github.com/Kong/shared-renovate/pull/8

Restrict automatic branch updates to scheduled hours. Previously, every time a branch was merged all Renovate branches would be updated and CI would run for all of them. Devs can still manually trigger branch updates outside of scheduled hours by checking the PR checkbox if needed.

docs: https://docs.renovatebot.com/configuration-options/#updateNotScheduled