### PR TITLE
feat: widen peerDependencies

### DIFF
--- a/kong-frontend-config.json
+++ b/kong-frontend-config.json
@@ -37,6 +37,24 @@
     },
     {
       "automerge": true,
+      "groupName": "all non-major peerDependencies with stable version",
+      "groupSlug": "all-minor-patch-peer",
+      "matchCurrentVersion": "!/^0/",
+      "matchDepTypes": [
+        "peerDependencies"
+      ],
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "rangeStrategy": "widen",
+      "minimumReleaseAge": "10 days"
+    },
+    {
+      "automerge": true,
       "groupName": "all kong scoped dependencies",
       "groupSlug": "all-kong-scopes",
       "matchPackagePatterns": [


### PR DESCRIPTION
When a devDependency in a package is bumped, if it’s also listed as a peerDependency, that version is also bumped even though the previous version/range would still be just fine to use in the downstream app as long as it's not a major version update.

[`widenPeerDependencies` docs](https://docs.renovatebot.com/presets-default/#widenpeerdependencies)