### PR TITLE
chore: ignore inquierer

### DIFF
--- a/kong-frontend-config.json
+++ b/kong-frontend-config.json
@@ -86,6 +86,15 @@
       "schedule": [
         "every weekday"
       ]
+    },
+    {
+      "groupName": "ignored dependencies",
+      "groupSlug": "all-kong-ui-ignored-dependencies",
+      "matchPackageNames": [
+        "inquirer",
+        "@types/inquirer"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Ignore `inquierer` for FE repos so we don't need to rebuild the CI flows right now