### PR TITLE
feat: group eslint dependencies

### DIFF
--- a/kong-frontend-config.json
+++ b/kong-frontend-config.json
@@ -37,7 +37,7 @@
         "minor",
         "patch"
       ],
-      "minimumReleaseAge": "10 days"
+      "minimumReleaseAge": "12 days"
     },
     {
       "automerge": true,
@@ -83,6 +83,20 @@
         "patch"
       ],
       "minimumReleaseAge": "2 hours",
+      "schedule": [
+        "every weekday"
+      ]
+    },
+    {
+      "automerge": true,
+      "groupName": "eslint",
+      "groupSlug": "eslint",
+      "matchPackageNames": ["/eslint/"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "minimumReleaseAge": "12 days",
       "schedule": [
         "every weekday"
       ]


### PR DESCRIPTION
Group any `eslint` related dependencies and increase the minimum age by 2 days.

Using a broad match to cover things like:

```
@nuxt/eslint
eslint
vite-plugin-eslint2
eslint-config-kong-ui
```