### PR TITLE
fix(github-actions): automerge all non-major github actions with stable version

### DIFF
--- a/kong-frontend-config.json
+++ b/kong-frontend-config.json
@@ -108,6 +108,16 @@
     },
     {
       "automerge": true,
+      "groupName": "all non-major github actions with stable version",
+      "groupSlug": "all-minor-patch-github-actions",
+      "matchCurrentVersion": "!/^v0/",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "12 days"
+    },
+    {
+      "automerge": true,
       "groupName": "eslint",
       "groupSlug": "eslint",
       "matchPackageNames": ["/eslint/"],


### PR DESCRIPTION
Previously, patch and minor version updates for Github actions would never match the "all non-major dependencies with stable version" grouping because Github action versions are prefixed with a "v". This change adds a new group that is specific to github actions that expects tags to be prefixed with a "v" (i.e. "v1.0.0").