### PR TITLE
ci(renovate): remove github-actions preset from kong-frontend-config

### DIFF
--- a/kong-frontend-config.json
+++ b/kong-frontend-config.json
@@ -5,8 +5,7 @@
     ":semanticCommits",
     ":automergeRequireAllStatusChecks",
     ":automergePatch",
-    ":automergeMinor",
-    "local>Kong/public-shared-renovate:github-actions"
+    ":automergeMinor"
   ],
   "dependencyDashboard": true,
   "rangeStrategy": "bump",


### PR DESCRIPTION
I unintentionally changed the way how github actions are pinned for the whole kong-frontend-config.json preset, so I'm reverting this change.