### PR TITLE
fix: disable pnpm engines range updates

### DIFF
--- a/kong-frontend-config.json
+++ b/kong-frontend-config.json
@@ -136,6 +136,18 @@
         "@types/inquirer"
       ],
       "enabled": false
+    },
+    {
+      "groupName": "pnpm engines range",
+      "groupSlug": "pnpm-engines",
+      "matchPackageNames": [
+        "pnpm"
+      ],
+      "matchDepTypes": [
+        "engines"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This resolves the pnpm engines range being bumped causing issues in downstream repos when the version there doesn't match.