### PR TITLE
chore(renovate): adjust postUpdateOptions for Go modules

### DIFF
--- a/go.json
+++ b/go.json
@@ -6,7 +6,10 @@
     "group:kubernetes",
     "group:pulumi"
   ],
-  "postUpdateOptions": ["gomodMassage", "gomodTidy"],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ],
   "packageRules": [
     {
       "groupName": "google.golang.org/genproto/googleapis/*",


### PR DESCRIPTION
Removed `gomodMassage` from `postUpdateOptions` in `go.json` because it caused issues by creating unnecessary "require" blocks in `go.mod`. Instead of adding new dependencies to existing blocks, it sometimes created separate blocks like:

```go
require (
	cel.dev/expr v0.16.1 // indirect
	filippo.io/edwards25519 v1.1.0 // indirect
)

require (
	NEW_DEP v0.0.1 // indirect
)
```

Added `gomodUpdateImportPaths` to `postUpdateOptions` to ensure Renovate updates import paths in source code for non-major releases, making dependency updates more seamless.