### PR TITLE
fix: do not override schedule

### DIFF
--- a/kong-frontend-config.json
+++ b/kong-frontend-config.json
@@ -45,10 +45,7 @@
         "@kong/**"
       ],
       "matchUpdateTypes": ["minor", "patch"],
-      "minimumReleaseAge": "2 hours",
-      "schedule": [
-        "every monday"
-      ]
+      "minimumReleaseAge": "2 hours"
     },
     {
       "automerge": true,
@@ -58,10 +55,7 @@
         "@kong-ui/**"
       ],
       "matchUpdateTypes": ["minor", "patch"],
-      "minimumReleaseAge": "2 hours",
-      "schedule": [
-        "every weekday"
-      ]
+      "minimumReleaseAge": "2 hours"
     },
     {
       "automerge": true,
@@ -71,10 +65,7 @@
         "@kong-ui-public/**"
       ],
       "matchUpdateTypes": ["minor", "patch"],
-      "minimumReleaseAge": "2 hours",
-      "schedule": [
-        "every weekday"
-      ]
+      "minimumReleaseAge": "2 hours"
     },
     {
       "automerge": true,
@@ -123,10 +114,7 @@
       "groupSlug": "eslint",
       "matchPackageNames": ["/eslint/"],
       "matchUpdateTypes": ["minor", "patch"],
-      "minimumReleaseAge": "12 days",
-      "schedule": [
-        "every weekday"
-      ]
+      "minimumReleaseAge": "12 days"
     },
     {
       "groupName": "ignored dependencies",


### PR DESCRIPTION
Rules were getting evaluated differently based on the day of the week. This PR removes the `schedule` overrides and utilizes a root schedule for all package rules.