### PR TITLE
feat(renovate): align commit messages with dependabot format for existing automations

### DIFF
--- a/backend.json
+++ b/backend.json
@@ -11,6 +11,7 @@
     "local>Kong/public-shared-renovate:github-actions",
     "local>Kong/public-shared-renovate:go"
   ],
+  "commitMessageAction": "bump",
   "packageRules": [
     {
       "matchPackageNames": [
@@ -20,6 +21,14 @@
         "github-actions"
       ],
       "enabled": false
+    },
+    {
+      "description": "Use 'from ... to ...' notation for version or digest changes across all dependencies, mirroring Dependabot's commit message style so existing automation (e.g., changelog generation) remains unaffected",
+      "matchPackageNames": [
+        "**"
+      ],
+      "commitMessageTopic": "{{{depName}}}",
+      "commitMessageExtra": "{{#if (or isMajor isMinor isPatch (and isPinDigest currentDigestShort))}}from {{#if isPinDigest}}{{{currentDigestShort}}}{{else}}{{#if isSingleVersion}}{{currentVersion}}{{else}}{{#if currentValue}}{{{currentValue}}}{{else}}{{{currentDigestShort}}}{{/if}}{{/if}}{{/if}} {{/if}}to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isSingleVersion}}{{newVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}"
     }
   ]
 }

--- a/github-actions.json
+++ b/github-actions.json
@@ -55,7 +55,7 @@
       "matchPackageNames": ["Kong/public-shared-actions/**"],
       "commitMessageTopic": "{{{packageName}}}",
       "commitMessageLowerCase": "never",
-      "commitMessageAction": "update",
+      "commitMessageAction": "bump",
       "pin": {
         "commitMessageAction": "pin"
       },


### PR DESCRIPTION
- Added "commitMessageAction" to backend.json for consistency
- Introduced a package rule using "from ... to ..." version notation
- Changed GitHub Actions commit message action from "update" to "bump"
- Ensures existing automations relying on dependabot-like messages remain functional