### PR TITLE
chore(renovate): run backend preset only before 4am on Monday

### DIFF
--- a/backend.json
+++ b/backend.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Preset designed for backend projects, it runs updates before 5am on weekdays, applies best practices, and uses shared configurations for GitHub Actions and Go dependencies. Automerge is disabled, git sign-off is required, a 'dependencies' label is added to PRs, and 'chore' is used as the semantic commit type for all updates",
-  "schedule": "before 5am every weekday",
+  "schedule": [
+    "before 4am on monday"
+  ],
   "extends": [
     "config:best-practices",
     ":automergeDisabled",


### PR DESCRIPTION
- Changed Renovate schedule from every weekday to only Monday before 4am (UTC)
- Reduces frequency of Renovate PRs for easier dependency management