### PR TITLE
fix: ignore kong-api-tests

### DIFF
--- a/kong-frontend-config.json
+++ b/kong-frontend-config.json
@@ -36,6 +36,15 @@
       "enabled": false
     },
     {
+      "matchPackageNames": [
+        "Kong/kong-api-tests"
+      ],
+      "matchDatasources": [
+        "github-actions"
+      ],
+      "enabled": false
+    },
+    {
       "automerge": true,
       "groupName": "all non-major dependencies with stable version",
       "groupSlug": "all-minor-patch",


### PR DESCRIPTION
Ignore `Kong/kong-api-tests` action for automated updates