### PR TITLE
chore(renovate): increase hourly PR limit to 15

### DIFF
--- a/backend.json
+++ b/backend.json
@@ -4,6 +4,7 @@
   "schedule": [
     "before 4am on monday"
   ],
+  "prHourlyLimit": 15,
   "extends": [
     "config:best-practices",
     ":automergeDisabled",


### PR DESCRIPTION
- Increased `prHourlyLimit` from 2 to 15
- With weekly scheduling, the previous limit (2 PRs/hour) caused Renovate to open only 2 PRs per week, despite appearing as an hourly limit
- This ensures all pending updates (up to 15) are processed each Monday