### PR TITLE
fix(renovate): allow digest updates for actions pinned by digest only

### DIFF
--- a/github-actions.json
+++ b/github-actions.json
@@ -45,7 +45,9 @@
       "pinDigests": false
     },
     {
-      "description": "Disable digest updates because regular version updates already handle them. Our custom regex manager manages these updates, and without this rule, Renovate would try to create two PRs, one for the digest and one for the regular version (major, minor, patch)",
+      "description": "Disable digest updates only for actions that are versioned (i.e., have a tag), to avoid duplicate PRs—one for the digest and one for the version. Digest updates remain enabled for actions pinned solely by digest (e.g., to track master/main), which are not covered by our versioning rules",
+      "matchCurrentValue": "/^[^\\.]+\\./",
+      "matchDepTypes": ["action"],
       "matchUpdateTypes": "digest",
       "enabled": false
     },

--- a/github-actions.json
+++ b/github-actions.json
@@ -47,7 +47,6 @@
     {
       "description": "Disable digest updates only for actions that are versioned (i.e., have a tag), to avoid duplicate PRs—one for the digest and one for the version. Digest updates remain enabled for actions pinned solely by digest (e.g., to track master/main), which are not covered by our versioning rules",
       "matchCurrentValue": "/^[^\\.]+\\./",
-      "matchDepTypes": ["action"],
       "matchUpdateTypes": "digest",
       "enabled": false
     },


### PR DESCRIPTION
Fixes bad rule that disabled all digest updates. Digest-only pins (e.g. master) were not getting updates, which is incorrect.

```json
          {
            "autoReplaceStringTemplate": "{{depName}}/regctl-installer@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
            "commitMessageTopic": "{{{depName}}} action",
            "currentDigest": "ce5fd131e371ffcdd7508b478cb223b3511a9183",
            "datasource": "github-tags",
            "depName": "regclient/actions",
            "depType": "action",
            "packageName": "regclient/actions",
            "replaceString": "regclient/actions/regctl-installer@ce5fd131e371ffcdd7508b478cb223b3511a9183",
            "versioning": "docker",
            "warnings": [],
            "updates": [
              {
                "updateType": "digest",
                "newDigest": "4d6888fcc4842c9630f60ebc91715a45dd9bd7a3",
                "branchName": "renovate/regclient-actions-digest"
              }
            ]
          },
          {
            "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
            "commitMessageTopic": "{{{depName}}} action",
            "currentDigest": "ea165f8d65b6e75b540449e92b4886f43607fa02",
            "currentValue": "v4.6.2",
            "currentVersion": "v4.6.2",
            "currentVersionAgeInDays": 63,
            "currentVersionTimestamp": "2025-03-19T17:34:59.000Z",
            "datasource": "github-tags",
            "depName": "actions/upload-artifact",
            "depType": "action",
            "fixedVersion": "v4.6.2",
            "packageName": "actions/upload-artifact",
            "registryUrl": "https://github.com",
            "replaceString": "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2",
            "sourceUrl": "https://github.com/actions/upload-artifact",
            "versioning": "docker",
            "warnings": [],
            "updates": []
          }
```