### PR TITLE
fix(preset/backend): improve commit message formatting and remove redundant config

### DIFF
--- a/backend.json
+++ b/backend.json
@@ -11,28 +11,19 @@
     ":gitSignOff",
     ":label(dependencies)",
     ":semanticCommitTypeAll(chore)",
-    "local>Kong/public-shared-renovate:github-actions",
-    "local>Kong/public-shared-renovate:go"
+    "Kong/public-shared-renovate:github-actions",
+    "Kong/public-shared-renovate:go"
   ],
   "commitMessageAction": "bump",
   "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",
   "packageRules": [
     {
-      "matchPackageNames": [
-        "tj-actions/changed-files"
-      ],
-      "matchDatasources": [
-        "github-actions"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Use 'from ... to ...' notation for version or digest changes across all dependencies, mirroring Dependabot's commit message style so existing automation (e.g., changelog generation) remains unaffected",
+      "description": "Use 'from ... to ...' notation for a version or digest changes across all dependencies, mirroring Dependabot's commit message style so existing automation (e.g., changelog generation) remains unaffected",
       "matchPackageNames": [
         "**"
       ],
       "commitMessageTopic": "{{{depName}}}",
-      "commitMessageExtra": "{{#if (or isMajor isMinor isPatch (and isPinDigest currentDigestShort))}}from {{#if isPinDigest}}{{{currentDigestShort}}}{{else}}{{#if isSingleVersion}}{{currentVersion}}{{else}}{{#if currentValue}}{{{currentValue}}}{{else}}{{{currentDigestShort}}}{{/if}}{{/if}}{{/if}} {{/if}}to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isSingleVersion}}{{newVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}"
+      "commitMessageExtra": "{{#if (or (and (or isMajor isMinor isPatch) (or (and isSingleVersion currentVersion) currentValue currentDigestShort)) (and (equals updateType 'digest') currentDigestShort))}}from {{#if (equals updateType 'digest')}}{{{currentDigestShort}}}{{else}}{{#if isSingleVersion}}{{currentVersion}}{{else}}{{#if currentValue}}{{{currentValue}}}{{else}}{{{currentDigestShort}}}{{/if}}{{/if}}{{/if}} {{/if}}to {{#if (or isPinDigest (equals updateType 'digest'))}}{{{newDigestShort}}}{{else}}{{#if isSingleVersion}}{{newVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}"
     }
   ]
 }


### PR DESCRIPTION
- Remove `local>` prefix from extended configs as it's misleading and just refers to the same remote source (ref. https://docs.renovatebot.com/config-presets/#local-presets)
- Fix `commitMessageExtra` to always include 'from ... to ...' in PR titles:
  - Before: `chore(deps): bump postgres to latest`, `chore(deps): bump redis to b3ad798`
  - After:  `chore(deps): bump postgres from 81f32a8 to 6efd0df`, `chore(deps): bump redis from 9abic82a to 6efd0df`
- Remove redundant rule disabling `tj-actions/changed-files` (already disabled in github-actions preset which is explicitly imported by the backend preset):
  - https://github.com/Kong/public-shared-renovate/blob/ab99c115ecba2067dbe7d70d2fab5e693dbe11b0/github-actions.json#L26-L34
  - https://github.com/Kong/public-shared-renovate/blob/ab99c115ecba2067dbe7d70d2fab5e693dbe11b0/backend.json#L14
- Fix grammar in one rule description (added "a" before "version")

---

Tested on Kuma's fork

<img width="1616" alt="image" src="https://github.com/user-attachments/assets/d8b110e0-b35d-4745-bce2-08f07cc79f66" />
