### PR TITLE
fix(preset/backend): include tag in commit message for digest updates with static tag

### DIFF
--- a/backend.json
+++ b/backend.json
@@ -22,7 +22,7 @@
       "matchPackageNames": [
         "**"
       ],
-      "commitMessageTopic": "{{{depName}}}",
+      "commitMessageTopic": "{{{depName}}}{{#if (and (equals updateType 'digest') (equals currentValue newValue) newValue)}}:{{{newValue}}}{{/if}}",
       "commitMessageExtra": "{{#if (or (and (or isMajor isMinor isPatch) (or (and isSingleVersion currentVersion) currentValue currentDigestShort)) (and (equals updateType 'digest') currentDigestShort))}}from {{#if (equals updateType 'digest')}}{{{currentDigestShort}}}{{else}}{{#if isSingleVersion}}{{currentVersion}}{{else}}{{#if currentValue}}{{{currentValue}}}{{else}}{{{currentDigestShort}}}{{/if}}{{/if}}{{/if}} {{/if}}to {{#if (or isPinDigest (equals updateType 'digest'))}}{{{newDigestShort}}}{{else}}{{#if isSingleVersion}}{{newVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}"
     }
   ]


### PR DESCRIPTION
Update commitMessageTopic to add `:{{newValue}}` to the dependency name for digest updates when `currentValue` and `newValue` are equal and not empty (e.g., for static Docker tags). This helps distinguish updates to the same image used with different tags

Examples:

- Before:

  ```
  chore(deps): bump gcr.io/distroless/base-nossl-debian12 from 1368c7b to 84c4a85
  chore(deps): bump gcr.io/distroless/base-nossl-debian12 from 393a396 to 081a62d
  ```

- After:

  ```
  chore(deps): bump gcr.io/distroless/base-nossl-debian12:debug from 1368c7b to 84c4a85
  chore(deps): bump gcr.io/distroless/base-nossl-debian12:debug-nonroot from 393a396 to 081a62d
  ```

---

Tested on Kuma's fork:

<img width="1595" alt="image" src="https://github.com/user-attachments/assets/2cdaf88b-58af-43fa-bce8-10dc529661f0" />
