### PR TITLE
feat(preset/renovate): add custom regex manager for Makefile-based tools

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,4 +14,6 @@
 
 /go.json @bartsmykla @baumac @slonka @lukidzi
 
+/makefile.json @bartsmykla @baumac @slonka @lukidzi
+
 /gateway.json5 @curiositycasualty @Water-Melon @fffonion

--- a/makefile.json
+++ b/makefile.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "This preset enables Renovate to detect and update tool versions declared in Makefiles",
+  "customManagers": [
+    {
+      "description": [
+        "Custom regex manager to update tools defined in Makefiles. Dependencies must follow a naming format like TOOL_NAME_VERSION and be preceded by a Renovate comment in this format: `# renovate: datasource=<source> depName=<name> [versioning=<type>] [registryUrl=<url>]`",
+        "Example:",
+        "# renovate: datasource=github-releases depName=cli/cli",
+        "GH_CLI_VERSION ?= 2.42.1"
+      ],
+      "customType": "regex",
+      "fileMatch": [
+        "(?:^|\\/)(?:Makefile|[^\\/]+\\.mk)$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*?_VERSION\\s?[:\\?]?=\\s?(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

We manage some tools in our Makefiles using version variables like `TOOL_NAME_VERSION`. These are not supported out of the box by Renovate, so updates to those tools have to be done manually. This PR adds a custom manager to automate those updates and reduce maintenance effort.

### Implementation information

* Added a new `makefile.json` Renovate preset

* Configures a custom regex manager for files like `Makefile` or `*.mk`

* Requires each version line to be preceded by a `# renovate:` comment with:

  * `datasource`, `depName`, and optionally `versioning` and `registryUrl`

    ```make
    # renovate: datasource=<source> depName=<name> [versioning=<type>] [registryUrl=<url>]
    ```

  * Example:

    ```make
    # renovate: datasource=github-releases depName=cli/cli
    GH_CLI_VERSION ?= 2.42.1
    
    ```

### Additional documentation

To test regexp you can use: https://regex101.com/r/XR22PL/1