### PR TITLE
fix(github-actions): correct version extraction for public-shared-actions tags

### DIFF
--- a/github-actions.json
+++ b/github-actions.json
@@ -9,32 +9,28 @@
     {
       "description": "This custom manager updates 'Kong/public-shared-actions' in YAML files located in '.github/', 'workflow-templates', or similar directories. The 'fileMatch' patterns match workflows and actions, aligning with the expressions used by the 'github-actions' manager (https://docs.renovatebot.com/modules/manager/github-actions/). It identifies dependencies with or without digests (e.g., '@v2.8.0' or '@digest # v2.8.0')",
       "customType": "regex",
-      "fileMatch": [
-        "(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$",
-        "(^|/)action\\.ya?ml$"
+      "managerFilePatterns": [
+        "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+        "/(^|/)action\\.ya?ml$/"
       ],
       "matchStrings": [
-        "(?<packageName>Kong\\/public-shared-actions\\/(?<depName>[^\\s@]+))@(?:(?<currentDigest>[^\\s]+) # )?v(?<currentValue>[^\\s]+)"
+        "(?<packageName>Kong\\/(?:public-shared-actions|shared-actions\\/actions)\\/(?<depName>[^\\s@]+))@(?:(?<currentDigest>\\w+)\\s*#\\s*)?v?(?<currentValue>(?:\\d+(?:\\.\\d)+|\\w+))"
       ],
       "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^(?:@{{{depName}}}@|v)(?<version>[0-9\\.]+)$",
+      "extractVersionTemplate": "^(?:@?{{{depName}}}[@_]|v)(?<version>[0-9\\.]+)$",
       "autoReplaceStringTemplate": "{{{packageName}}}@{{#if newDigest}}{{{newDigest}}} # {{/if}}v{{{newVersion}}}",
       "versioningTemplate": "semver"
     }
   ],
   "packageRules": [
     {
-      "matchPackageNames": [
-        "tj-actions/changed-files"
-      ],
-      "matchDatasources": [
-        "github-actions"
-      ],
+      "matchPackageNames": ["tj-actions/changed-files"],
+      "matchDatasources": ["github-actions"],
       "enabled": false
     },
     {
       "description": "Manage Kong/public-shared-actions updates using the custom manager, so disable the default GitHub Actions manager for these",
-      "matchPackageNames": ["Kong/public-shared-actions"],
+      "matchPackageNames": ["/^Kong\\/(?:public-)?shared-actions/"],
       "matchManagers": ["github-actions"],
       "enabled": false
     },
@@ -53,7 +49,7 @@
     {
       "description": "Ensure commit and PR titles use the full package name for better clarity. Prevent lowercase conversion of the package name to keep `Kong` correctly capitalized. Set commit actions to use lowercase (e.g., `update`, `pin`, `replace`, `roll back`). Also update the PR body table to reflect the full name and include a link to the source code",
       "matchManagers": ["regex"],
-      "matchPackageNames": ["Kong/public-shared-actions/**"],
+      "matchPackageNames": ["/^Kong\\/(?:public-)?shared-actions\\//"],
       "commitMessageTopic": "{{{packageName}}}",
       "commitMessageLowerCase": "never",
       "commitMessageAction": "bump",

--- a/github-actions.json
+++ b/github-actions.json
@@ -17,7 +17,7 @@
         "(?<packageName>Kong\\/public-shared-actions\\/(?<depName>[^\\s@]+))@(?:(?<currentDigest>\\w+)\\s*#\\s*)?v?(?<currentValue>(?:\\d+(?:\\.\\d)+|\\w+))"
       ],
       "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^(?:@?{{{depName}}}[@_]|v)(?<version>[0-9\\.]+)$",
+      "extractVersionTemplate": "^@?{{{depName}}}@v?(?<version>[0-9\\.]+)$",
       "autoReplaceStringTemplate": "{{{packageName}}}@{{#if newDigest}}{{{newDigest}}} # {{/if}}v{{{newVersion}}}",
       "versioningTemplate": "semver"
     }
@@ -30,7 +30,7 @@
     },
     {
       "description": "Manage Kong/public-shared-actions updates using the custom manager, so disable the default GitHub Actions manager for these",
-      "matchPackageNames": ["Kong/public-shared-actions"],
+      "matchPackageNames": ["/^Kong\\/public-shared-actions/"],
       "matchManagers": ["github-actions"],
       "enabled": false
     },
@@ -49,7 +49,7 @@
     {
       "description": "Ensure commit and PR titles use the full package name for better clarity. Prevent lowercase conversion of the package name to keep `Kong` correctly capitalized. Set commit actions to use lowercase (e.g., `update`, `pin`, `replace`, `roll back`). Also update the PR body table to reflect the full name and include a link to the source code",
       "matchManagers": ["regex"],
-      "matchPackageNames": ["Kong/public-shared-actions/**"],
+      "matchPackageNames": ["/^Kong\\/public-shared-actions/"],
       "commitMessageTopic": "{{{packageName}}}",
       "commitMessageLowerCase": "never",
       "commitMessageAction": "bump",

--- a/github-actions.json
+++ b/github-actions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "This preset consists of common configuration for updating GitHub Actions. It adds custom manager to update github-action dependencies for specific repositories. It also includes rules for dependencies like 'slsa-framework/slsa-github-generator' and extends presets for pinning GitHub Action digests to semver versions",
+  "description": "This preset consists of a common configuration for updating GitHub Actions. It adds a custom manager to update github-action dependencies for specific repositories. It also includes rules for dependencies like 'slsa-framework/slsa-github-generator' and extends presets for pinning GitHub Action digests to semver versions",
   "extends": [
     "helpers:pinGitHubActionDigests",
     "helpers:pinGitHubActionDigestsToSemver"
@@ -14,7 +14,7 @@
         "/(^|/)action\\.ya?ml$/"
       ],
       "matchStrings": [
-        "(?<packageName>Kong\\/(?:public-shared-actions|shared-actions\\/actions)\\/(?<depName>[^\\s@]+))@(?:(?<currentDigest>\\w+)\\s*#\\s*)?v?(?<currentValue>(?:\\d+(?:\\.\\d)+|\\w+))"
+        "(?<packageName>Kong\\/public-shared-actions\\/(?<depName>[^\\s@]+))@(?:(?<currentDigest>\\w+)\\s*#\\s*)?v?(?<currentValue>(?:\\d+(?:\\.\\d)+|\\w+))"
       ],
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^(?:@?{{{depName}}}[@_]|v)(?<version>[0-9\\.]+)$",
@@ -30,12 +30,12 @@
     },
     {
       "description": "Manage Kong/public-shared-actions updates using the custom manager, so disable the default GitHub Actions manager for these",
-      "matchPackageNames": ["/^Kong\\/(?:public-)?shared-actions/"],
+      "matchPackageNames": ["Kong/public-shared-actions"],
       "matchManagers": ["github-actions"],
       "enabled": false
     },
     {
-      "description": "SLSA-GitHub-Generator cannot be pinned by digest More info: https://github.com/slsa-framework/slsa-github-generator/blob/main/RENOVATE.md",
+      "description": "Digest cannot pin SLSA-GitHub-Generator More info: https://github.com/slsa-framework/slsa-github-generator/blob/main/RENOVATE.md",
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["slsa-framework/slsa-github-generator"],
       "pinDigests": false
@@ -49,7 +49,7 @@
     {
       "description": "Ensure commit and PR titles use the full package name for better clarity. Prevent lowercase conversion of the package name to keep `Kong` correctly capitalized. Set commit actions to use lowercase (e.g., `update`, `pin`, `replace`, `roll back`). Also update the PR body table to reflect the full name and include a link to the source code",
       "matchManagers": ["regex"],
-      "matchPackageNames": ["/^Kong\\/(?:public-)?shared-actions\\//"],
+      "matchPackageNames": ["Kong/public-shared-actions/**"],
       "commitMessageTopic": "{{{packageName}}}",
       "commitMessageLowerCase": "never",
       "commitMessageAction": "bump",

--- a/github-actions.json
+++ b/github-actions.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "This preset consists of a common configuration for updating GitHub Actions. It adds a custom manager to update github-action dependencies for specific repositories. It also includes rules for dependencies like 'slsa-framework/slsa-github-generator' and extends presets for pinning GitHub Action digests to semver versions",
+  "description": "This preset consists of common configuration for updating GitHub Actions. It adds custom manager to update github-action dependencies for specific repositories. It also includes rules for dependencies like 'slsa-framework/slsa-github-generator' and extends presets for pinning GitHub Action digests to semver versions",
   "extends": [
     "helpers:pinGitHubActionDigests",
     "helpers:pinGitHubActionDigestsToSemver"
@@ -24,18 +24,22 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["tj-actions/changed-files"],
-      "matchDatasources": ["github-actions"],
+      "matchPackageNames": [
+        "tj-actions/changed-files"
+      ],
+      "matchDatasources": [
+        "github-actions"
+      ],
       "enabled": false
     },
     {
       "description": "Manage Kong/public-shared-actions updates using the custom manager, so disable the default GitHub Actions manager for these",
-      "matchPackageNames": ["/^Kong\\/public-shared-actions/"],
+      "matchPackageNames": ["Kong/public-shared-actions"],
       "matchManagers": ["github-actions"],
       "enabled": false
     },
     {
-      "description": "Digest cannot pin SLSA-GitHub-Generator More info: https://github.com/slsa-framework/slsa-github-generator/blob/main/RENOVATE.md",
+      "description": "SLSA-GitHub-Generator cannot be pinned by digest More info: https://github.com/slsa-framework/slsa-github-generator/blob/main/RENOVATE.md",
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["slsa-framework/slsa-github-generator"],
       "pinDigests": false
@@ -49,7 +53,7 @@
     {
       "description": "Ensure commit and PR titles use the full package name for better clarity. Prevent lowercase conversion of the package name to keep `Kong` correctly capitalized. Set commit actions to use lowercase (e.g., `update`, `pin`, `replace`, `roll back`). Also update the PR body table to reflect the full name and include a link to the source code",
       "matchManagers": ["regex"],
-      "matchPackageNames": ["/^Kong\\/public-shared-actions/"],
+      "matchPackageNames": ["Kong/public-shared-actions/**"],
       "commitMessageTopic": "{{{packageName}}}",
       "commitMessageLowerCase": "never",
       "commitMessageAction": "bump",


### PR DESCRIPTION
## Motivation

Renovate did not correctly detect versions for `Kong/public-shared-actions/**` when releases used the new tag format. This sometimes led to wrong upgrades, because the old fallback allowed plain `vX.Y.Z` tags without a sub-action name to override proper sub-action releases. For example, when `security-actions/sca@4.1.5` existed but the repo also had a top-level `v4.2.0`, Renovate tried to update `security-actions/sca` to `4.2.0`. This change fixes detection, removes the unsafe fallback, and aligns with Renovate’s current manager file pattern requirements.

## Implementation information

- Updated `matchStrings` and `extractVersionTemplate` to correctly capture release tags with sub-action paths and optional `@` or `v` prefixes, covering all expected variants:
  - `@a/b@1.2.3` (format used before)
  - `c/d/e@4.5.6` (current format)
  - `@f/g/@v7.8.9`
  - `h/i/j@v10.11.12`
- Validated the new `matchStrings` regexp: https://regex101.com/r/jPVxkO/3
- Validated the new `extractVersionTemplate` regexp: https://regex101.com/r/KTXpU5/1
- Removed the fallback that matched raw `vX.Y.Z` tags without a sub-action name to prevent incorrect upgrades from top-level tags
- Switched to `managerFilePatterns` to follow Renovate’s updated requirements for custom managers
- Verified in a fork:
  - Released [v4.2.0](https://github.com/bartsmykla/public-shared-actions/releases/tag/v4.2.0) (highest version)
  - Released [@security-actions/sca@4.1.4](https://github.com/bartsmykla/public-shared-actions/releases/tag/%40security-actions%2Fsca%404.1.4)
  - Released [security-actions/sca@4.1.5](https://github.com/bartsmykla/public-shared-actions/releases/tag/security-actions%2Fsca%404.1.5)
  - Used `bartsmykla/public-shared-actions/security-actions/sca` (`v4.1.4`) in a workflow
  - Ran Renovate manually
  - Renovate opened the correct update PR: https://github.com/bartsmykla/kuma/pull/491

## Supporting documentation

Closes: https://github.com/Kong/public-shared-actions/issues/301