### PR TITLE
feat(presets): add changed-files preset and adopt official makefile mgr

### DIFF
--- a/backend.json
+++ b/backend.json
@@ -15,9 +15,9 @@
     "config:best-practices",
     "schedule:earlyMondays",
     ":automergeDisabled",
+    ":disableRateLimiting",
     ":gitSignOff",
     ":label(dependencies)",
-    ":prHourlyLimitNone",
     ":semanticCommitTypeAll(chore)",
     "Kong/public-shared-renovate:github-actions",
     "Kong/public-shared-renovate:go"

--- a/backend.json
+++ b/backend.json
@@ -1,15 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Preset designed for backend projects, it runs updates before 5am on weekdays, applies best practices, and uses shared configurations for GitHub Actions and Go dependencies. Automerge is disabled, git sign-off is required, a 'dependencies' label is added to PRs, and 'chore' is used as the semantic commit type for all updates",
-  "schedule": [
-    "before 4am on monday"
+  "description": [
+    " This preset targets backend repositories. It schedules dependency updates for early Monday",
+    " mornings, applies the Renovate best practices and extends shared presets for GitHub Actions and",
+    " Go modules. Automerge is disabled, git sign-off is required, a 'dependencies' label is added",
+    " to PRs, and 'chore' is used as the semantic commit type",
+    "",
+    " PR hourly limits are removed to prevent updates from queueing for a full week. When limits are",
+    " set and more updates than the configured 'prHourlyLimit' are generated during the early-Monday",
+    " window, the rate-limited ones wait until the next scheduled window (the following Monday). If",
+    " teams prefer limits, they can set project-specific values in their local Renovate config"
   ],
-  "prHourlyLimit": 15,
   "extends": [
     "config:best-practices",
+    "schedule:earlyMondays",
     ":automergeDisabled",
     ":gitSignOff",
     ":label(dependencies)",
+    ":prHourlyLimitNone",
     ":semanticCommitTypeAll(chore)",
     "Kong/public-shared-renovate:github-actions",
     "Kong/public-shared-renovate:go"
@@ -18,10 +26,12 @@
   "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",
   "packageRules": [
     {
-      "description": "Use 'from ... to ...' notation for a version or digest changes across all dependencies, mirroring Dependabot's commit message style so existing automation (e.g., changelog generation) remains unaffected",
-      "matchPackageNames": [
-        "**"
+      "description": [
+        " Standardize commit messages to use 'from ... to ...' notation for version and digest",
+        " changes across all dependencies. This mirrors Dependabot's style so downstream automation",
+        " (e.g., changelog generation) remains compatible"
       ],
+      "matchPackageNames": ["**"],
       "commitMessageTopic": "{{{depName}}}{{#if (and (equals updateType 'digest') (equals currentValue newValue) newValue)}}:{{{newValue}}}{{/if}}",
       "commitMessageExtra": "{{#if (or (and (or isMajor isMinor isPatch) (or (and isSingleVersion currentVersion) currentValue currentDigestShort)) (and (equals updateType 'digest') currentDigestShort))}}from {{#if (equals updateType 'digest')}}{{{currentDigestShort}}}{{else}}{{#if isSingleVersion}}{{currentVersion}}{{else}}{{#if currentValue}}{{{currentValue}}}{{else}}{{{currentDigestShort}}}{{/if}}{{/if}}{{/if}} {{/if}}to {{#if (or isPinDigest (equals updateType 'digest'))}}{{{newDigestShort}}}{{else}}{{#if isSingleVersion}}{{newVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}"
     }

--- a/github-actions-changed-files.json
+++ b/github-actions-changed-files.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    " Shared preset that blocks automatic updates for 'tj-actions/changed-files' and requires",
+    " manual bumps. We currently do not trust automated updates of this dependency and want a human",
+    " to review, test, and consciously approve each version change. Renovate PRs are disabled",
+    " on purpose; maintainers should update it manually when deemed safe and appropriate",
+    " Context: prior malicious release: https://github.com/advisories/ghsa-mrrh-fwg8-r2c3"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["tj-actions/changed-files"],
+      "matchDatasources": ["github-actions"],
+      "enabled": false
+    }
+  ]
+}

--- a/github-actions.json
+++ b/github-actions.json
@@ -1,9 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "This preset consists of common configuration for updating GitHub Actions. It adds custom manager to update github-action dependencies for specific repositories. It also includes rules for dependencies like 'slsa-framework/slsa-github-generator' and extends presets for pinning GitHub Action digests to semver versions",
+  "description": [
+    " This preset provides a shared configuration for updating GitHub Actions. It adds a custom",
+    " manager to handle action dependencies in selected repositories and includes general policy",
+    " rules (such as digest pinning behavior). It also extends presets that map digests to semver",
+    " versions"
+  ],
   "extends": [
     "helpers:pinGitHubActionDigests",
-    "helpers:pinGitHubActionDigestsToSemver"
+    "helpers:pinGitHubActionDigestsToSemver",
+    "Kong/public-shared-renovate:github-actions-changed-files"
   ],
   "customManagers": [
     {
@@ -25,7 +31,7 @@
         "   - Versions support 1–4 numeric sections and optional prerelease/build parts with",
         "     hyphens/dots; an optional leading 'v' is allowed",
         "",
-        " Version extraction (extractVersionTemplate) — examples",
+        " Version extraction (extractVersionTemplate) - examples",
         "   - @security-actions/sca@1.2.3",
         "   - @security-actions/scan-rust@v4.5.6",
         "   - security-actions/semgrep@7.8.9.10",
@@ -34,7 +40,7 @@
         "   - scan-rust@v0.1.2",
         "   - a/b/c/d/e/lua-lint@v3.4.5.6-abc.foo",
         "",
-        " matchStrings — examples of full matches",
+        " matchStrings - examples of full matches",
         "   # VALID",
         "   - Kong/public-shared-actions/security-actions/sca@1.2.3",
         "   - Kong/public-shared-actions/security-actions/sca@1.2.3.4 # foo",
@@ -84,34 +90,44 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": [
-        "tj-actions/changed-files"
+      "description": [
+        " Manage Kong/public-shared-actions updates using the custom manager, so disable the default",
+        " GitHub Actions manager for these"
       ],
-      "matchDatasources": [
-        "github-actions"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Manage Kong/public-shared-actions updates using the custom manager, so disable the default GitHub Actions manager for these",
       "matchPackageNames": ["Kong/public-shared-actions"],
       "matchManagers": ["github-actions"],
       "enabled": false
     },
     {
-      "description": "SLSA-GitHub-Generator cannot be pinned by digest More info: https://github.com/slsa-framework/slsa-github-generator/blob/main/RENOVATE.md",
+      "description": [
+        " Do not pin SLSA-GitHub-Generator by digest. The project publishes versioned tags and",
+        " explicitly recommends disabling digest pinning for Renovate so updates track tags only.",
+        " Pinning to a commit SHA can break provenance and reusability expectations of the generator",
+        " and will fight with the upstream release /tag workflow",
+        " More info: https://github.com/slsa-framework/slsa-github-generator/blob/main/RENOVATE.md"
+      ],
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["slsa-framework/slsa-github-generator"],
       "pinDigests": false
     },
     {
-      "description": "Disable digest updates only for actions that are versioned (i.e., have a tag), to avoid duplicate PRs—one for the digest and one for the version. Digest updates remain enabled for actions pinned solely by digest (e.g., to track master/main), which are not covered by our versioning rules",
+      "description": [
+        " Disable digest updates only for actions that are versioned (i.e., have a tag), to avoid",
+        " duplicate PRs-one for the digest and one for the version. Digest updates remain enabled",
+        " for actions pinned solely by digest (e.g., to track master/main), which are not covered",
+        " by our versioning rules"
+      ],
       "matchCurrentValue": "/^[^.]+\\./",
       "matchUpdateTypes": "digest",
       "enabled": false
     },
     {
-      "description": "Ensure commit and PR titles use the full package name for better clarity. Prevent lowercase conversion of the package name to keep `Kong` correctly capitalized. Set commit actions to use lowercase (e.g., `update`, `pin`, `replace`, `roll back`). Also update the PR body table to reflect the full name and include a link to the source code",
+      "description": [
+        " Ensure commit and PR titles use the full package name for better clarity. Prevent",
+        " lowercase conversion of the package name to keep `Kong` correctly capitalized. Set commit",
+        " actions to use lowercase (e.g., `update`, `pin`, `replace`, `roll back`). Also update",
+        " the PR body table to reflect the full name and include a link to the source code"
+      ],
       "matchManagers": ["regex"],
       "matchPackageNames": ["Kong/public-shared-actions/**"],
       "commitMessageTopic": "{{{packageName}}}",

--- a/go.json
+++ b/go.json
@@ -1,25 +1,21 @@
 {
-  "description": "Designed for Go projects, this preset enables the 'gomod' manager and ensures 'gomodMassage' and 'gomodTidy' are run after updates. It contains common manager configurations and groups for Go modules updates to simplify dependency management",
+  "description": [
+    " This preset targets Go repositories. It enables the 'gomod' manager, runs 'gomodTidy' and",
+    " 'gomodUpdateImportPaths' after updates, and provides common manager settings and update",
+    " groups to simplify module maintenance"
+  ],
   "extends": [
     ":gomod",
     "group:goOpenapi",
     "group:kubernetes",
-    "group:pulumi"
+    "group:pulumi",
+    "Kong/public-shared-renovate:github-actions-changed-files"
   ],
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"
   ],
   "packageRules": [
-    {
-      "matchPackageNames": [
-        "tj-actions/changed-files"
-      ],
-      "matchDatasources": [
-        "github-actions"
-      ],
-      "enabled": false
-    },
     {
       "groupName": "google.golang.org/genproto/googleapis/*",
       "groupSlug": "genproto-googleapis",

--- a/makefile.json
+++ b/makefile.json
@@ -1,22 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "This preset enables Renovate to detect and update tool versions declared in Makefiles",
-  "customManagers": [
-    {
-      "description": [
-        "Custom regex manager to update tools defined in Makefiles. Dependencies must follow a naming format like TOOL_NAME_VERSION and be preceded by a Renovate comment in this format: `# renovate: datasource=<source> depName=<name> [versioning=<type>] [registryUrl=<url>]`",
-        "Example:",
-        "# renovate: datasource=github-releases depName=cli/cli",
-        "GH_CLI_VERSION ?= 2.42.1"
-      ],
-      "customType": "regex",
-      "fileMatch": [
-        "(?:^|\\/)(?:Makefile|[^\\/]+\\.mk)$"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*?_VERSION\\s?[:\\?]?=\\s?(?<currentValue>.*)\\s"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    }
+  "description": [
+    " [DEPRECATED]",
+    " This preset has been replaced by Renovate's official preset 'customManagers:makefileVersions'",
+    " Please update your configuration to extend directly from 'customManagers:makefileVersions'"
+  ],
+  "extends": [
+    "customManagers:makefileVersions"
   ]
 }


### PR DESCRIPTION
## Motivation

Several renovate presets needed cleanup and improvements. We were duplicating the disable rule for `tj-actions/changed-files` in multiple presets, which made it harder to maintain and less clear why this action is treated specially. Backend projects were also using a hardcoded manual schedule and an hourly PR limit that delayed updates by a full week when limits were hit. In addition, we still maintained a custom Makefile manager even though Renovate now provides an official one. Documentation in many presets was written as single-line strings, making them harder to read and understand.

## Implementation information

- Created a dedicated `github-actions-changed-files.json` preset that disables automated updates for `tj-actions/changed-files`. This rule already existed but was duplicated in several presets. Now it is centralized with a clear description and reused wherever needed
- Updated `backend.json`:
  - Replaced the manual schedule with the official `schedule:earlyMondays` preset. This keeps the same schedule but relies on a shared, well-documented definition
  - Removed `prHourlyLimit` and switched to `:prHourlyLimitNone`. This avoids queueing updates for a full week and ensures all updates are raised immediately during the Monday window
- Updated `go.json` to reuse the new `github-actions-changed-files` preset instead of keeping its own disable rule
- Updated `github-actions.json` to extend the new `github-actions-changed-files` preset and improve package rules
- Deprecated `makefile.json` and switched it to extend Renovate’s official `customManagers:makefileVersions` preset
- Rewrote descriptions across all presets into clear multi-line explanations for much better readability and maintainability