### PR TITLE
feat(presets/security): add base and extended security presets

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,10 +10,16 @@
 
 /github-actions.json @bartsmykla @baumac @slonka @lukidzi
 
+/github-actions-changed-files.json  @bartsmykla @baumac @slonka @lukidzi
+
 /backend.json @bartsmykla @baumac @slonka @lukidzi
 
 /go.json @bartsmykla @baumac @slonka @lukidzi
 
 /makefile.json @bartsmykla @baumac @slonka @lukidzi
+
+/security-base.json @bartsmykla @baumac @slonka @lukidzi
+
+/security-extended.json @bartsmykla @baumac @slonka @lukidzi
 
 /gateway.json5 @curiositycasualty @Water-Melon @fffonion

--- a/github-actions.json
+++ b/github-actions.json
@@ -128,23 +128,15 @@
         " actions to use lowercase (e.g., `update`, `pin`, `replace`, `roll back`). Also update",
         " the PR body table to reflect the full name and include a link to the source code"
       ],
-      "matchManagers": ["regex"],
+      "matchManagers": ["custom.regex"],
       "matchPackageNames": ["Kong/public-shared-actions/**"],
       "commitMessageTopic": "{{{packageName}}}",
       "commitMessageLowerCase": "never",
       "commitMessageAction": "bump",
-      "pin": {
-        "commitMessageAction": "pin"
-      },
-      "pinDigest": {
-        "commitMessageAction": "pin"
-      },
-      "replacement": {
-        "commitMessageAction": "replace"
-      },
-      "rollback": {
-        "commitMessageAction": "roll back"
-      },
+      "pin": {"commitMessageAction": "pin"},
+      "pinDigest": {"commitMessageAction": "pin"},
+      "replacement": {"commitMessageAction": "replace"},
+      "rollback": {"commitMessageAction": "roll back"},
       "prBodyDefinitions": {
         "Package": "[{{{packageName}}}]({{{sourceUrl}}}) ([source]({{{sourceUrl}}}/tree/{{#if newVersion}}%40{{{depName}}}%40{{{newVersion}}}{{else}}{{#if newDigest}}{{{newDigest}}}{{else}}main{{/if}}{{/if}}/{{{depName}}}))"
       }

--- a/security-base.json
+++ b/security-base.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    " Base security preset for Renovate shared across Kong repositories. It serves as the central",
+    " place for baseline settings and conventions related to security such as how security-related",
+    " updates and alerts are handled across projects",
+    "",
+    " This preset is intentionally parameterless and contains only common, non-routing behavior.",
+    " Use the 'security-extended' preset if you want to add labels and automatically request",
+    " reviewers"
+  ],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "description": [
+      " Documenting non-default settings for vulnerability alerts",
+      " commitMessageSuffix: set to empty to remove Renovate's default '[SECURITY]' suffix",
+      "   from PR titles. Rationale: some teams use release notes or changelog generators that",
+      "   expect standard dependency update PR titles without extra suffixes; keeping titles clean",
+      "   avoids misclassification and keeps tooling output consistent across repositories",
+      " Other keys here mirror Renovate defaults and are included explicitly for clarity"
+    ],
+    "branchTopic": "{{{datasource}}}-{{{depNameSanitized}}}-vulnerability",
+    "commitMessageSuffix": "",
+    "dependencyDashboardApproval": false,
+    "enabled": true,
+    "groupName": null,
+    "minimumReleaseAge": null,
+    "prCreation": "immediate",
+    "rangeStrategy": "update-lockfile",
+    "schedule": [],
+    "vulnerabilityFixStrategy": "lowest"
+  },
+  "packageRules": [
+    {
+      "description": [
+        " Treat GitHub Actions under 'Kong/public-shared-actions/security/**' as security-related.",
+        " Create PRs immediately to prioritize security workflows; no labels or reviewers are added",
+        " at this base level (dynamic labeling/assignment can be added via the 'security' preset)"
+      ],
+      "matchPackageNames": ["Kong/public-shared-actions/security/**"],
+      "dependencyDashboardApproval": false,
+      "groupName": null,
+      "minimumReleaseAge": null,
+      "prCreation": "immediate",
+      "schedule": []
+    }
+  ]
+}

--- a/security-extended.json
+++ b/security-extended.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    " Parameterized security preset for Renovate that builds on the shared base preset",
+    " It enables and standardizes vulnerability alert PRs via 'security-base' and additionally:",
+    " - Adds a label to each security PR using the first preset argument (arg0)",
+    " - Requests a review via 'additionalReviewers' using the second preset argument (arg1)",
+    "",
+    " It also augments the base behavior that treats updates to GitHub Actions under",
+    " 'Kong/public-shared-actions/security/**' as security-related. This preset adds the same",
+    " label (arg0) and reviewer (arg1) to those PRs",
+    "",
+    " Arguments",
+    " - arg0: A single GitHub label to apply to all security PRs (e.g., 'security')",
+    " - arg1: A single user or team name to request as a reviewer (e.g., 'bob' or 'team:foo')",
+    "   [WARNING]: If assigning a team as reviewer, use the 'team:' prefix and only the last part",
+    "              of the team name e.g., 'team:foo' for '@organization/foo'",
+    "   [NOTE]: Reviewers are only added at PR creation time and are not modified afterward",
+    "",
+    " More information",
+    " - Preset parameters: https://docs.renovatebot.com/config-presets/#preset-parameters",
+    " - Reviewers: https://docs.renovatebot.com/configuration-options/#reviewers",
+    "",
+    " Example of usage (without JSON quoting):",
+    " {",
+    "   extends: [Kong/public-shared-renovate:security-extended(security,team:security-managers)]",
+    " }"
+  ],
+  "extends": ["Kong/public-shared-renovate:security-base"],
+  "vulnerabilityAlerts": {
+    "addLabels": ["{{arg0}}"],
+    "additionalReviewers": ["{{arg1}}"]
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": ["Kong/public-shared-actions/security/**"],
+      "addLabels": ["{{arg0}}"],
+      "additionalReviewers": ["{{arg1}}"]
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation

We want to standardize how Renovate handles security updates and vulnerability alerts across repositories. Additionally, some cleanup was needed in `CODEOWNERS` and the `github-actions.json` preset.

## Implementation information

### Added `security-base.json` preset

- Provides baseline behavior for vulnerability alerts without hardcoded labels or reviewers  
- Enables `osvVulnerabilityAlerts`  
- Configures `vulnerabilityAlerts` to remove Renovate's default `[SECURITY]` suffix from commit messages
- Adds package rule to treat `Kong/public-shared-actions/security/**` actions as security-related with immediate PR creation  

### Added `security-extended.json` preset

- Extends `security-base.json`  
- Adds a label from the first provided argument (`{{arg0}}`)  
- Assigns an additional reviewer from the second provided argument (`{{arg1}}`)  
- Allows repositories to customize labels and reviewers while still benefiting from the baseline security handling  

### `github-actions` preset

- Adjusted `github-actions.json` according to validator results  (renamed custom manager from `regex` to `custom.regex`)

### CODEOWNERS

- Added entries for both new security presets  
- Added missing entry for `github-actions-changed-files.json`  

## Supporting documentation

- Validation performed with:

  ```sh
  npx --yes --package renovate@41.115.6 -- renovate-config-validator github-actions.json
  ```