### PR TITLE
feat(github-actions): enforce digest pinning for public-shared-actions

### DIFF
--- a/github-actions.json
+++ b/github-actions.json
@@ -7,7 +7,7 @@
     " versions"
   ],
   "extends": [
-    "helpers:pinGitHubActionDigests",
+    "group:githubArtifactActions",
     "helpers:pinGitHubActionDigestsToSemver",
     "Kong/public-shared-renovate:github-actions-changed-files"
   ],
@@ -80,12 +80,11 @@
         "/(^|/)action\\.ya?ml$/"
       ],
       "matchStrings": [
-        "(?<packageName>Kong\\/public-shared-actions\\/(?:[0-9A-Za-z._-]*\\/)*(?<depName>[^\\s@]+))@(?:(?<currentDigest>[0-9A-Fa-f]{7,40})[\\t ]*#[\\t ]*)?v?(?<currentValue>(?:[0-9]+(?:\\.[0-9]+){0,3}(?:-[0-9A-Za-z.-]+)?|[0-9A-Fa-f]{7,40}))(?<indentation>\\s|$)"
+        "(?<packageName>Kong/public-shared-actions/(?:[0-9A-Za-z._-]*/)*(?<depName>[^\\s@]+))@(?:(?<currentDigest>[0-9A-Fa-f]{7,40})[\\t ]*#[\\t ]*)?v?(?<currentValue>[0-9]*(?:\\.[0-9]+){0,3}(?:-[0-9A-Za-z.-]+)?)(?<indentation>\\s|$)"
       ],
       "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^@?(?:[0-9A-Za-z._-]*\\/)*{{{depName}}}[@_](?<version>v?(?:[0-9]+(?:\\.[0-9]+){0,3}(?:-[0-9A-Za-z.-]+)?))$",
-      "autoReplaceStringTemplate": "{{{packageName}}}@{{#if newDigest}}{{{newDigest}}} # {{{prettyNewVersion}}}{{else}}{{{newValue}}}{{/if}}{{{indentation}}}",
-      "versioningTemplate": "semver-coerced"
+      "extractVersionTemplate": "^@?(?:[0-9A-Za-z._-]*/)*{{{depName}}}[@_]v?(?<version>[0-9]+(?:\\.[0-9]+){0,3}(?:-[0-9A-Za-z.-]+)?)$",
+      "autoReplaceStringTemplate": "{{{packageName}}}@{{#if newDigest}}{{{newDigest}}} # v{{/if}}{{{newValue}}}{{{indentation}}}"
     }
   ],
   "packageRules": [
@@ -97,6 +96,21 @@
       "matchPackageNames": ["Kong/public-shared-actions"],
       "matchManagers": ["github-actions"],
       "enabled": false
+    },
+    {
+      "description": [
+        " Group and pin updates for public-shared-actions discovered by this custom manager",
+        " - Grouping switched from depName to packageName, so each PR groups by the full action",
+        "   path",
+        " - pinDigests enabled to always pin sub-action references to a commit SHA for security",
+        "   and stable tracking",
+        " - groupName uses the full packageName to protect against two sub-actions with the same",
+        "   name that lives under different directories"
+      ],
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["Kong/public-shared-actions/**"],
+      "pinDigests": true,
+      "groupName": "{{{packageName}}}"
     },
     {
       "description": [
@@ -112,21 +126,10 @@
     },
     {
       "description": [
-        " Disable digest updates only for actions that are versioned (i.e., have a tag), to avoid",
-        " duplicate PRs-one for the digest and one for the version. Digest updates remain enabled",
-        " for actions pinned solely by digest (e.g., to track master/main), which are not covered",
-        " by our versioning rules"
-      ],
-      "matchCurrentValue": "/^[^.]+\\./",
-      "matchUpdateTypes": "digest",
-      "enabled": false
-    },
-    {
-      "description": [
         " Ensure commit and PR titles use the full package name for better clarity. Prevent",
-        " lowercase conversion of the package name to keep `Kong` correctly capitalized. Set commit",
-        " actions to use lowercase (e.g., `update`, `pin`, `replace`, `roll back`). Also update",
-        " the PR body table to reflect the full name and include a link to the source code"
+        " lowercase conversion of the package name to keep 'Kong' correctly capitalized. Set commit",
+        " actions to use lowercase (e.g., 'update', 'pin', 'replace', 'roll back'). Also update",
+        " the PR body table to reflect the full name"
       ],
       "matchManagers": ["custom.regex"],
       "matchPackageNames": ["Kong/public-shared-actions/**"],
@@ -138,8 +141,36 @@
       "replacement": {"commitMessageAction": "replace"},
       "rollback": {"commitMessageAction": "roll back"},
       "prBodyDefinitions": {
-        "Package": "[{{{packageName}}}]({{{sourceUrl}}}) ([source]({{{sourceUrl}}}/tree/{{#if newVersion}}%40{{{depName}}}%40{{{newVersion}}}{{else}}{{#if newDigest}}{{{newDigest}}}{{else}}main{{/if}}{{/if}}/{{{depName}}}))"
+        "Package": "[{{{packageName}}}]({{{sourceUrl}}}){{#if newName}}{{#unless (equals depName newName)}} → {{{newNameLinked}}}{{/unless}}{{/if}}"
       }
+    },
+    {
+      "description": [
+        " Force-upgrade and pin for Kong/public-shared-actions sub-actions. This rule upgrades",
+        " repositories using versions below 4 (e.g., v1 – v3) to the latest v4+ sub-action tag and",
+        " automatically pins each reference to its commit digest. It is prioritized and always",
+        " re-created until merged, bypassing normal schedules and Renovate rate limits so",
+        " repositories get secure, updatable references immediately.",
+        "",
+        " Why: The monorepo now publishes per-sub-action tags in the form '<sub-action>@<version>'",
+        " (e.g., 'workflow-notification@4.0.1') instead of plain 'vX.Y.Z' tags. Older references",
+        " like '...@v2' cannot be auto-migrated by tag alone. Upgrading to v4+ plus digest pinning",
+        " avoids tag-name mismatches because Renovate tracks updates by commit SHA and also annotates",
+        " the line with a friendly '# vX.Y.Z' comment for humans"
+      ],
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["Kong/public-shared-actions/**"],
+      "matchCurrentValue": "/^v?[0-3](?:\\.[0-9]+){0,2}$/",
+      "extends": [":disableRateLimiting", ":prImmediately"],
+      "recreateWhen": "always",
+      "schedule": ["at any time"],
+      "minimumReleaseAge": null,
+      "updateNotScheduled": true,
+      "dependencyDashboardApproval": false,
+      "prHeader": "> [!CAUTION]\n> This PR upgrades `Kong/public-shared-actions` sub-action to v4+ and pins it to the commit digest. It is prioritized (bypasses schedules/rate limits). Closing this PR will not stop it; Renovate will automatically reopen or recreate it until it is merged.\n\n---",
+      "prBodyNotes": [
+        "---\n> [!NOTE]\n> #### Mandatory upgrade to v4+ with automatic digest pinning for `Kong/public-shared-actions`\n>\n> Renovate is configured to upgrade any `Kong/public-shared-actions` sub-action still on versions below 4 to the latest v4+ version. As part of this upgrade, it will automatically pin each reference to the exact commit digest (and keep that digest refreshed over time).\n>\n> #### Background\n>\n> The `Kong/public-shared-actions` monorepo now publishes per-sub-action tags in the form `<sub-action>@<version>` (for example, `workflow-notification@4.0.1`) instead of plain `vX.Y.Z` tags. Older references like `...@v2` cannot be auto-migrated by tag alone.\n>\n> #### Why tag-only migration is not supported\n>\n> Important: Renovate will not change the tag format for you. Migrating from the older plain `vX.Y.Z` tags to the new per-sub-action tags while keeping tag-only references would require rewriting refs such as `...@v2` to a different tag name like `...@sca@5.1.1`. This contradicts the goal of dependency update automation because it relies on humans to manage tag-name changes and ongoing updates, which our automation is not designed to perform. For this reason, tag-only migration is not supported.\n>\n> Instead, this preset enforces digest pinning. Renovate resolves releases by tag, then writes the reference as the commit SHA for that release with a trailing human-friendly comment (e.g., `...@<sha> # v5.1.1`). Tracking commits rather than tag names keeps updates automated and robust even if tag naming conventions change.\n>\n> #### Security\n>\n> GitHub Actions security guidance recommends pinning third-party actions to a full commit SHA to protect against tag moving and supply-chain attacks.\n>\n> #### References\n>\n> - https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Motivation

Workflows depending on `Kong/public-shared-actions` could break when Renovate updated old versions of sub-actions (< v4) to later ones. The releases existed, but their names and tag formats did not match what GitHub expected (e.g., `workflow-notification@4.0.1` instead of `v4.0.1`). This mismatch meant Renovate could generate updates pointing to tags that GitHub could not resolve, leaving critical workflows like Slack notifications at risk of silently failing. To prevent this, Renovate is now configured to enforce digest pinning and to automatically upgrade any sub-actions below v4 to v4+. With these changes, actions are always referenced by their commit SHA with an inline version comment, ensuring they resolve correctly regardless of tag format and keeping workflows secure and stable.

## Implementation information

### Updated regex manager

- Adjusted `matchStrings` to better capture versions
- Changed `autoReplaceStringTemplate` to use `newDigest` and `newValue`
- Removed `versioningTemplate: semver-coerced` since it’s the default when not specified

### Replaced old digest rule

- Removed obsolete rule disabling duplicate digest PRs
- Added new rule that:
  - Forces upgrade of sub-actions below v4 (e.g., v1–v3) to latest v4+
  - Pins each reference to its commit digest
  - Always re-creates PRs until merged
  - Bypasses schedules and rate limits for fast updates
- Updated description to explain the motivation and behavior

The enforced bump PRs include detailed notes that explain why this upgrade is mandatory. Renovate does not attempt to rewrite plain `vX.Y.Z` references into new `<sub-action>@<version>` tags, because this would require human intervention and ongoing manual updates. Instead, the rule enforces digest pinning: Renovate resolves the correct release by tag and then rewrites the reference as a commit SHA with a trailing version comment (e.g., `...@<sha> # v5.1.1`). This keeps updates automated, robust against tag naming changes, and aligned with GitHub’s security guidance on pinning to commit SHAs.

### Added `group:githubArtifactActions` preset

- Groups updates of common GitHub-provided actions for easier management

### Testing

The changes were tested on my fork ([commit e9504af6](https://github.com/kumahq/kuma/commit/e9504af6322fa5344ee986f66e9a551078986947)), and Renovate correctly opened PRs for different versioning cases:

- [`workflow-notification@v2`](https://github.com/bartsmykla/kuma/pull/521): only major semver section → bumped to latest `4.0.1` and pinned by digest  
- [`security-actions/sca@v2.3`](https://github.com/bartsmykla/kuma/pull/519): major and minor semver sections → bumped to latest `5.1.2` and pinned by digest  
- [`security-actions/semgrep@v1.7.0`](https://github.com/bartsmykla/kuma/pull/520): full semver → bumped to latest `5.0.0` and pinned by digest  
- [`bartsmykla/security-actions/sca@v1`](https://github.com/bartsmykla/kuma/pull/517): fork with highest version in legacy format (`v6.0.0`) → correctly ignored legacy format and bumped to latest new format `5.0.0`, pinned by digest  
- [`pr-previews/validate@v1`](https://github.com/bartsmykla/kuma/pull/518): bumped to latest `4.0.0` and pinned by digest  

These tests confirm that Renovate now handles major-only, major+minor, full semver, forked legacy format, and regular updates consistently, while enforcing digest pinning and secure automated upgrades.

## Supporting documentation

- GitHub security guidance: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions