### PR TITLE
ci(renovate): add preset for kumahq/go-control-plane replacements

### DIFF
--- a/modules/kuma/go-control-plane.json
+++ b/modules/kuma/go-control-plane.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    " Manage updates for 'github.com/kumahq/go-control-plane' replacements in Go modules. This preset",
+    " adds a custom regex manager and package rules to handle replace directives consistently.",
+    "",
+    " Why this exists",
+    " - Upstream 'github.com/envoyproxy/go-control-plane' v0.12.0 introduced a potential deadlock;",
+    "   this is tracked in: https://github.com/envoyproxy/go-control-plane/issues/875",
+    " - Kuma temporarily relies on the fork 'github.com/kumahq/go-control-plane' and publishes",
+    "   'vX.Y.Z-kong-...' builds. This preset keeps those replace directives consistent and groups",
+    "   related updates (including subpackages) for easier review"
+  ],
+  "customManagers": [
+    {
+      "description": [
+        " Custom regex manager for updating 'github.com/kumahq/go-control-plane' replacements",
+        " in go.mod files.",
+        " - Matches the root module and any subpackages under 'go-control-plane/**'",
+        " - Captures the current value and replaces it with the latest version",
+        " - Extracts versions in the form 'vX.Y.Z-kong-...' for kuma-maintained builds"
+      ],
+      "customType": "regex",
+      "fileMatch": ["(^|/)go\\.mod$"],
+      "matchStrings": [
+        "(?<packageName>github.com\\/kumahq\\/(?<depName>go-control-plane)) (?<currentValue>[^\\s]+)",
+        "(?<packageName>github.com\\/kumahq\\/go-control-plane\\/(?<depName>.+)) (?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "go",
+      "depTypeTemplate": "replace",
+      "extractVersionTemplate": "^(?:{{{depName}}}\\/)?(?<version>v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>kong-.+))",
+      "autoReplaceStringTemplate": "{{{packageName}}} {{{newVersion}}}",
+      "versioningTemplate": "loose"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": [
+        " Disable updates by the default Go module manager for 'github.com/kumahq/go-control-plane'",
+        " entries when they are under a 'replace' directive. This ensures the custom regex manager is",
+        " the single source of truth for these updates"
+      ],
+      "groupName": "github.com/kumahq/go-control-plane*",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["github.com/kumahq/go-control-plane{/,}**"],
+      "matchDepTypes": ["replace"],
+      "enabled": false
+    },
+    {
+      "description": [
+        " Ensure updates to 'github.com/kumahq/go-control-plane' replacements use the custom",
+        " regex manager. After updating, run 'go mod tidy' and update import paths when required.",
+        " Commit message topic is set to the full package name"
+      ],
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["go"],
+      "matchDepTypes": ["replace"],
+      "matchPackageNames": ["github.com/kumahq/go-control-plane{/,}**"],
+      "commitMessageTopic": "{{{packageName}}}",
+      "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"]
+    },
+    {
+      "description": [
+        " Group updates for 'github.com/envoyproxy/go-control-plane' and the fork",
+        " 'github.com/kumahq/go-control-plane' (including subpackages) into a single PR group"
+      ],
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["github.com/{envoyproxy,kumahq}/go-control-plane{/,}**"],
+      "groupName": "github.com/envoyproxy/go-control-plane*",
+      "groupSlug": "github.com-envoyproxy-go-control-plane"
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation

Upstream `github.com/envoyproxy/go-control-plane` introduced a potential deadlock in v0.12.0 (see https://github.com/envoyproxy/go-control-plane/issues/875). To avoid this issue, Kuma temporarily relies on the fork `github.com/kumahq/go-control-plane`, which publishes builds in the format `vX.Y.Z-kong-...`. These versions are used via replace directives in `go.mod`, but Renovate does not manage them correctly by default. Without a dedicated preset, updates could be inconsistent, harder to review, or skipped entirely. This preset ensures that all replace directives for `kumahq/go-control-plane` and related subpackages are managed in a consistent, automated way.

## Implementation information

### Added `modules/kuma/go-control-plane.json`

- Introduced a custom regex manager that matches `go.mod` replace directives for `github.com/kumahq/go-control-plane` and its subpackages  
- Extracts versions in the `vX.Y.Z-kong-...` format used by Kuma builds  
- Uses `versioningTemplate: loose` and `autoReplaceStringTemplate` to update replaces directly  
- Disabled default handling of these replaces by the `gomod` manager to ensure the regex manager is authoritative  
- Configured post-update actions (`gomodTidy` and `gomodUpdateImportPaths`) so module graph and imports are refreshed after updates  
- Added package rules to group updates for both `github.com/envoyproxy/go-control-plane` and `github.com/kumahq/go-control-plane` (including subpackages) into a single PR for easier review  
- Documented the motivation and background directly in the preset description for maintainers  

## Result

- Renovate now reliably manages all `go-control-plane` replace directives in one place  
- Updates to both upstream and forked packages are grouped into a single PR, making them easier to review and track  
- Ensures Kuma stays on maintained fork versions while avoiding regressions from upstream issues  
- Keeps module graph and imports clean through automated tidy and import path updates  

## Supporting documentation

- Upstream issue: https://github.com/envoyproxy/go-control-plane/issues/875