### PR TITLE
feat(*): update backend and go presets for clarity and reliability

### DIFF
--- a/backend.json
+++ b/backend.json
@@ -19,11 +19,10 @@
     ":gitSignOff",
     ":label(dependencies)",
     ":semanticCommitTypeAll(chore)",
-    "Kong/public-shared-renovate:github-actions",
-    "Kong/public-shared-renovate:go"
+    "Kong/public-shared-renovate:github-actions#1.12.0",
+    "Kong/public-shared-renovate:go#1.12.0"
   ],
   "commitMessageAction": "bump",
-  "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",
   "packageRules": [
     {
       "description": [
@@ -32,8 +31,8 @@
         " (e.g., changelog generation) remains compatible"
       ],
       "matchPackageNames": ["**"],
-      "commitMessageTopic": "{{{depName}}}{{#if (and (equals updateType 'digest') (equals currentValue newValue) newValue)}}:{{{newValue}}}{{/if}}",
-      "commitMessageExtra": "{{#if (or (and (or isMajor isMinor isPatch) (or (and isSingleVersion currentVersion) currentValue currentDigestShort)) (and (equals updateType 'digest') currentDigestShort))}}from {{#if (equals updateType 'digest')}}{{{currentDigestShort}}}{{else}}{{#if isSingleVersion}}{{currentVersion}}{{else}}{{#if currentValue}}{{{currentValue}}}{{else}}{{{currentDigestShort}}}{{/if}}{{/if}}{{/if}} {{/if}}to {{#if (or isPinDigest (equals updateType 'digest'))}}{{{newDigestShort}}}{{else}}{{#if isSingleVersion}}{{newVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}"
+      "commitMessageTopic": "{{#if (containsString packageName '/public-shared-actions/')}}{{{packageName}}}{{else}}{{depName}}{{/if}}{{#if (and (equals updateType 'digest') (equals currentValue newValue) newValue)}}:{{{newValue}}}{{/if}}",
+      "commitMessageExtra": "{{#if (or (and (or isMajor isMinor isPatch) (or (and isSingleVersion currentVersion) currentValue currentDigestShort)) (and (equals updateType 'digest') currentDigestShort))}}from {{#if (equals updateType 'digest')}}{{{currentDigestShort}}}{{else if currentValue}}{{{currentValue}}}{{else}}{{{currentDigestShort}}}{{/if}} {{/if}}to {{#if (or isPinDigest (equals updateType 'digest'))}}{{{newDigestShort}}}{{else if isSingleVersion}}{{newVersion}}{{else if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}"
     }
   ]
 }

--- a/go.json
+++ b/go.json
@@ -1,15 +1,19 @@
 {
   "description": [
-    " This preset targets Go repositories. It enables the 'gomod' manager, runs 'gomodTidy' and",
-    " 'gomodUpdateImportPaths' after updates, and provides common manager settings and update",
-    " groups to simplify module maintenance"
+    " Base Go preset intended to be extended by more complete presets. It provides the common,",
+    " suggested, and scoped Renovate configuration for Go-based projects. Use this as the foundation",
+    " for Go repositories; higher-level presets can add scheduling, labels, reviewers, automerge",
+    " policies, or repository-specific rules on top"
   ],
   "extends": [
-    ":gomod",
     "group:goOpenapi",
     "group:kubernetes",
     "group:pulumi",
-    "Kong/public-shared-renovate:github-actions-changed-files"
+    "group:aws-sdk-goMonorepo",
+    "group:aws-sdk-go-v2Monorepo",
+    "group:opentelemetry-goMonorepo",
+    "group:opentelemetry-go-contribMonorepo",
+    "group:testcontainers-goMonorepo"
   ],
   "postUpdateOptions": [
     "gomodTidy",


### PR DESCRIPTION
## Motivation

The backend and Go Renovate presets needed cleanup to make them easier to use and keep them consistent with best practices. The backend preset used unpinned presets and had extra settings that added little value. The Go preset was missing clear explanation of its role and did not group common dependencies, which made reviews noisier. This PR fixes these issues.

## Implementation information

### Backend preset

- Pin `github-actions` and `go` presets to `#1.12.0` for consistency
- Make commit messages clearer for `Kong/public-shared-actions` updates
- Keep digest and version info but simplify how the extra message is built
- Remove the PR body override since it was not needed

### Go preset

- Update description to explain it is a base Go preset that should be extended
- Drop direct `:gomod` extend to keep it modular
- Add grouping for common dependencies to reduce PR noise:
  - AWS SDK v1
  - AWS SDK v2
  - OpenTelemetry (core and contrib)
  - Testcontainers