### PR TITLE
chore(kuma): migrate go-control-plane matcher and add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,3 +23,5 @@
 /security-extended.json @bartsmykla @baumac @slonka @lukidzi
 
 /gateway.json5 @curiositycasualty @Water-Melon @fffonion
+
+/modules/kuma @bartsmykla @slonka @lukidzi

--- a/modules/kuma/go-control-plane.json
+++ b/modules/kuma/go-control-plane.json
@@ -21,7 +21,7 @@
         " - Extracts versions in the form 'vX.Y.Z-kong-...' for kuma-maintained builds"
       ],
       "customType": "regex",
-      "fileMatch": ["(^|/)go\\.mod$"],
+      "managerFilePatterns": ["/(^|/)go\\.mod$/"],
       "matchStrings": [
         "(?<packageName>github.com\\/kumahq\\/(?<depName>go-control-plane)) (?<currentValue>[^\\s]+)",
         "(?<packageName>github.com\\/kumahq\\/go-control-plane\\/(?<depName>.+)) (?<currentValue>[^\\s]+)"


### PR DESCRIPTION
## Motivation

The Renovate config migration replaced the deprecated `fileMatch` field with `managerFilePatterns` for custom managers. The `modules/kuma/go-control-plane.json` preset was still using the old field, which could lead to Renovate ignoring `go.mod` files. In addition, ownership of the `modules/kuma` presets was not defined. This PR applies the migration and adds missing ownership information.

## Implementation information

### Migrate matcher

- Replaced `fileMatch` with `managerFilePatterns` using `/(^|/)go\.mod$/`
- Ensures compatibility with Renovate’s current config format and guarantees that `go.mod` files are matched

### Add CODEOWNERS

- Added a CODEOWNERS entry for `/modules/kuma` assigning ownership to the appropriate people