### PR TITLE
chore(makefile): add deprecation warning to makefile preset alias

### DIFF
--- a/makefile.json
+++ b/makefile.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": [
-    " [DEPRECATED]",
-    " This preset has been replaced by Renovate's official preset 'customManagers:makefileVersions'",
-    " Please update your configuration to extend directly from 'customManagers:makefileVersions'"
+    " [DEPRECATED] This preset forwards to Renovate's official 'customManagers:makefileVersions' preset",
+    " It is a compatibility alias kept to preserve backwards compatibility"
   ],
-  "extends": [
-    "customManagers:makefileVersions"
+  "extends": ["customManagers:makefileVersions"],
+  "prBodyNotes": [
+    "---\n> [!WARNING]\n> #### Deprecated preset: `Kong/public-shared-renovate:makefile`\n>\n> This preset has been replaced by Renovate's official preset [`customManagers:makefileVersions`](https://docs.renovatebot.com/presets-customManagers/#custommanagersmakefileversions). Although not identical, the official preset is a superset and a safe drop-in replacement.\n>\n> #### Action required\n>\n> Update your Renovate config to extend directly from `customManagers:makefileVersions`.\n>\n> #### Timeline\n>\n> This compatibility alias is temporary and is scheduled for removal in January 2026.\n>\n> #### Reference\n>\n> See the Renovate documentation for details: https://docs.renovatebot.com/presets-customManagers/#custommanagersmakefileversions"
   ]
 }


### PR DESCRIPTION
## Motivation

The `makefile.json` preset was already an alias forwarding to Renovate's official `customManagers:makefileVersions`. While it worked as intended, users had no clear indication that it was temporary. We want to give teams clear warnings so they know to migrate in time.

## Implementation information

- Kept the preset as an alias to `customManagers:makefileVersions`  
- Updated the description to clarify it is a compatibility alias  
- Added `prBodyNotes` so Renovate PRs display a visible deprecation warning with instructions and a timeline for removal  

## Result

There is no change in functionality, but teams now get clear deprecation warnings in Renovate PRs, helping them plan migration to the official `customManagers:makefileVersions` preset before January 2026.