### PR TITLE
fix(github-actions): drop incident preset from alias to avoid note override

### DIFF
--- a/github-actions.json
+++ b/github-actions.json
@@ -4,10 +4,7 @@
     " [MOVED] This preset has been relocated to 'base/github-actions.json'. It is now an alias",
     " that extends the new location to preserve backwards compatibility"
   ],
-  "extends": [
-    "Kong/public-shared-renovate//base/github-actions",
-    "Kong/public-shared-renovate//security/incidents/github-actions/tj-actions-changed-files"
-  ],
+  "extends": ["Kong/public-shared-renovate//base/github-actions"],
   "prBodyNotes": [
     "---\n> [!WARNING]\n> #### Moved preset: `Kong/public-shared-renovate:github-actions`\n>\n> Your config references a deprecated preset. To prevent disruption, this file temporarily aliases to `Kong/public-shared-renovate//base/github-actions`.\n>\n> #### Action required\n>\n> Update your Renovate config to extend directly from `Kong/public-shared-renovate//base/github-actions`\n>\n> #### Examples\n>\n> Before (any of the following):\n>\n> ```json\n> { \"extends\": [\"Kong/public-shared-renovate:github-actions\"] }\n> { \"extends\": [\"Kong/public-shared-renovate:github-actions.json\"] }\n> { \"extends\": [\"local>Kong/public-shared-renovate:github-actions\"] }\n> { \"extends\": [\"github>Kong/public-shared-renovate:github-actions\"] }\n> ```\n>\n> After:\n>\n> ```json\n> { \"extends\": [\"Kong/public-shared-renovate//base/github-actions\"] }\n> ```\n>\n> #### Timeline\n>\n> This alias will be removed in **January 2026**.\n"
   ]


### PR DESCRIPTION
## Motivation

Consumer repos were seeing only the incident preset PR note, which hid the moved preset warning that explains the alias and the required migration. The alias also duplicated behavior already provided by the base preset.

## Implementation information

Updated `github-actions.json` to remove the incident preset from `extends` and keep only `Kong/public-shared-renovate//base/github-actions`. This avoids PR note conflicts and redundant configuration. Considered keeping both and tweaking `prBodyNotes` merging, but that adds complexity without real value since the base preset already covers the needed behavior.