### PR TITLE
chore(gw): Updated Kong Gateway base preset

### DIFF
--- a/scoped/kong/gateway.json
+++ b/scoped/kong/gateway.json
@@ -8,6 +8,7 @@
     " https://docs.konghq.com/gateway/latest/support-policy/#main"
   ],
   "extends": [
+    "Kong/public-shared-renovate//base/github-actions",
     "Kong/public-shared-renovate//overrides/labels(mend,renovate)",
     "Kong/public-shared-renovate//overrides/security-labels(security)"
   ],

--- a/scoped/kong/gateway.json
+++ b/scoped/kong/gateway.json
@@ -51,7 +51,6 @@
     { "matchMessage": "/^Response that has failed validation/", "newLogLevel": "debug" },
     { "matchMessage": "/custom datasource/", "newLogLevel": "debug" },
     { "matchMessage": "/^Error while evaluating/", "newLogLevel": "debug" },
-    { "matchMessage": "/^Response that has failed validation/", "newLogLevel": "debug" },
     { "matchMessage": "/^prTitle: /", "newLogLevel": "debug" },
     { "matchMessage": "/^Branch lists/", "newLogLevel": "trace" },
     { "matchMessage": "/^branch\\.isModified\\(\\) = true/", "newLogLevel": "trace" }

--- a/scoped/kong/gateway.json
+++ b/scoped/kong/gateway.json
@@ -1,78 +1,102 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": [
-    " Kong Gateway base preset for Renovate. Builds on Renovate best practices and keeps PRs fresh",
-    " by extending 'config:best-practices' and ':rebaseStalePrs'. Enables config migration and the",
-    " dependency dashboard for visibility (see https://docs.renovatebot.com/config-presets/).",
+    " Kong Gateway base preset for Renovate.",
     "",
     " Target branches include Gateway Enterprise LTS lines and active non‑LTS via pattern matching,",
     " plus master branches and the repo default. Reference: Kong Gateway support policy",
-    " https://docs.konghq.com/gateway/latest/support-policy/#main",
-    " - EE LTS: next/2.8.x.x, next/3.4.x.x, next/3.10.x.x",
-    " - EE non‑LTS (pattern): /^next\\/3\\.(?:[7-9]|1[1-9])\\.x\\.x$/",
-    " - Masters and default: enterprise-master, community-master, $default",
-    "",
-    " Labels added to all Renovate PRs: dependencies, chore, renovate, skip-changelog,",
-    " skip-pr-template-validation.",
-    "",
-    " Managers: limited to GitHub Actions (only useful when you want to restrict managers).",
-    " See discussion: https://github.com/renovatebot/renovate/discussions/29663",
-    "",
-    " Throughput guardrails: concurrent branches/PRs/hourly limits set to 20; stale branches are",
-    " pruned automatically.",
-    "",
-    " Log level remap tuning to reduce noise and surface issues:",
-    " - DIY errors: demote repeated lookup/errors to debug or warn",
-    " - '... is not updated ...': escalate to error",
-    " - Config validation errors: error",
-    " - Custom manager output: rise to debug/warn for easier troubleshooting",
-    " - PR creation titles: debug",
-    " - Misc noisy traces (branch lists, 'isModified'): keep at trace",
-    "",
-    " No custom managers/datasources are defined here; ignoreUnstable=false; packageRules reserved"
+    " https://docs.konghq.com/gateway/latest/support-policy/#main"
   ],
   "extends": [
-    "config:best-practices",
-    ":rebaseStalePrs"
+    "Kong/public-shared-renovate//overrides/labels(mend,renovate)",
+    "Kong/public-shared-renovate//overrides/security-labels(security)"
   ],
-  "baseBranches": [
+  "baseBranchPatterns": [
     "$default",
     "next/2.8.x.x",
     "next/3.4.x.x",
-    "next/3.10.x.x",
-    "/^next\\/3\\.(?:[7-9]|1[1-9])\\.x\\.x$/",
-    "enterprise-master",
-    "community-master"
+    "next/3.14.x.x",
+    "next/3.18.x.x",
+    "next/3.22.x.x",
+    "/^next\\/3\\.(9|1[0-9])\\.x.*$/"
   ],
   "enabledManagers": [
-    "github-actions"
+    "github-actions",
+    "custom.regex"
   ],
   "labels": [
-    "dependencies",
-    "chore",
-    "renovate",
+    "renovate:{{baseBranch}}",
+    "renovate:{{updateType}}",
+    "renovate-manager:{{manager}}",
     "skip-changelog",
     "skip-pr-template-validation"
   ],
   "ignoreUnstable": false,
   "pruneStaleBranches": true,
   "logLevelRemap": [
-    { "newLogLevel": "warn", "matchMessage": "/^Dependency .+ has unsupported/unversioned value/" },
-    { "newLogLevel": "warn", "matchMessage": "/^Found no satisfying versions with/" },
-    { "newLogLevel": "debug", "matchMessage": "/^lookupUpdates error/" },
-    { "newLogLevel": "debug", "matchMessage": "/^lookupUpdates/" },
-    { "newLogLevel": "error", "matchMessage": "/ is not updated /" },
-    { "newLogLevel": "error", "matchMessage": "/^Config validation errors found/" },
-    { "newLogLevel": "debug", "matchMessage": "/HTTP request/" },
-    { "newLogLevel": "debug", "matchMessage": "/Skipping bump because newValue is the same/" },
-    { "newLogLevel": "debug", "matchMessage": "/^Custom manager fetcher/" },
-    { "newLogLevel": "debug", "matchMessage": "/^Error while evaluating JSONata expression/" },
-    { "newLogLevel": "debug", "matchMessage": "/^Response that has failed validation/" },
-    { "newLogLevel": "debug", "matchMessage": "/custom datasource/" },
-    { "newLogLevel": "debug", "matchMessage": "/^Error while evaluating/" },
-    { "newLogLevel": "debug", "matchMessage": "/^Response that has failed validation/" },
-    { "newLogLevel": "debug", "matchMessage": "/^prTitle: /" },
-    { "newLogLevel": "trace", "matchMessage": "/^Branch lists/" },
-    { "newLogLevel": "trace", "matchMessage": "/^branch\\.isModified\\(\\) = true/" }
+    { "matchMessage": "/findCommitOfTag/", "newLogLevel": "debug" },
+    { "matchMessage": "/^lookupUpdates error/", "newLogLevel": "debug" },
+    { "matchMessage": "/^No currentVersion or lockedVersion found/", "newLogLevel": "debug" },
+    { "matchMessage": "/^Dependency .+ has unsupported/unversioned value/", "newLogLevel": "warn" },
+    { "matchMessage": "/^repository problems/", "newLogLevel": "warn" },
+    { "matchMessage": "/^lookupUpdates/", "newLogLevel": "debug" },
+    { "matchMessage": "/ is not updated /", "newLogLevel": "error" },
+    { "matchMessage": "/^Config validation errors found/", "newLogLevel": "error" },
+    { "matchMessage": "/HTTP request/", "newLogLevel": "debug" },
+    { "matchMessage": "/Skipping bump because newValue is the same/", "newLogLevel": "debug" },
+    { "matchMessage": "/^Found no satisfying versions with/", "newLogLevel": "warn" },
+    { "matchMessage": "/^Custom manager fetcher/", "newLogLevel": "debug" },
+    { "matchMessage": "/^Error while evaluating JSONata expression/", "newLogLevel": "debug" },
+    { "matchMessage": "/^Response that has failed validation/", "newLogLevel": "debug" },
+    { "matchMessage": "/custom datasource/", "newLogLevel": "debug" },
+    { "matchMessage": "/^Error while evaluating/", "newLogLevel": "debug" },
+    { "matchMessage": "/^Response that has failed validation/", "newLogLevel": "debug" },
+    { "matchMessage": "/^prTitle: /", "newLogLevel": "debug" },
+    { "matchMessage": "/^Branch lists/", "newLogLevel": "trace" },
+    { "matchMessage": "/^branch\\.isModified\\(\\) = true/", "newLogLevel": "trace" }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)perf\\.yml$/"],
+      "matchStrings": [
+        "uses: ben-z/gh-action-mutex@(?<currentDigest>[0-9a-f]{40}) # (?<currentValue>v.+?)\n"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?-(?<prerelease>[^-\\.]+)[-\\.](?<build>\\d+)$",
+      "depNameTemplate": "ben-z/gh-action-mutex",
+      "depTypeTemplate": "custom.action"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["/^actions\\/.*/"],
+      "groupName": "1st party actions",
+      "groupSlug": "1st-party-actions"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["/^docker\\/.*/"],
+      "groupName": "official docker actions",
+      "groupSlug": "official-docker-actions"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["/^kong\\/.*/i"],
+      "groupName": "kong actions",
+      "groupSlug": "kong-actions"
+    },
+    {
+      "matchDepNames": ["ben-z/gh-action-mutex"],
+      "matchManagers": ["!/custom\\.regex/"],
+      "enabled": false
+    },
+    {
+      "matchDepTypes":["action"],
+      "matchDepNames":["kong/kong-license"],
+      "overrideDatasource": "git-refs",
+      "overridePackageName": "https://github.com/kong/kong-license"
+    }
   ]
 }


### PR DESCRIPTION
Updated Kong Gateway base preset for Renovate with new support policy links, extended base branches, and added custom managers.

See also: https://github.com/Kong/kong-ee/pull/11162