### PR TITLE
revert: javascript range strategy

### DIFF
--- a/base/javascript.json
+++ b/base/javascript.json
@@ -38,7 +38,7 @@
       "matchPackageNames": [
         "*"
       ],
-      "rangeStrategy": "auto"
+      "rangeStrategy": "bump"
     },
     {
       "matchCategories": [


### PR DESCRIPTION
Revert the `rangeStrategy` change -- we actually prefer to update both the lockfile **and** `package.json` to be explicit