### PR TITLE
feat(kuma): add golang upgrade groupset

### DIFF
--- a/scoped/kuma/mise-tool-grouping.json
+++ b/scoped/kuma/mise-tool-grouping.json
@@ -46,6 +46,14 @@
       ],
       "matchDepNames": ["{registry.k8s.io/,}kubectl"],
       "groupName": "kubectl"
+    },
+    {
+      "description": [
+        "Group Go language version updates into a single PR across all managers (gomod, mise,",
+        "Makefile, etc.) so mise.toml and go.mod stay in sync"
+      ],
+      "matchDatasources": ["golang-version"],
+      "groupName": "go"
     }
   ]
 }


### PR DESCRIPTION
## Context

When there is new release of golang usually we receive one PR with mise.toml update https://github.com/kumahq/kuma/pull/15587/changes but there is no change in go.mod which creates versions drift

## Implementation

Added a grouping rule for golang version