### PR TITLE
fix(base/javascript): minimumReleaseAge not considered

### DIFF
--- a/base/javascript.json
+++ b/base/javascript.json
@@ -28,9 +28,15 @@
     ":gitSignOff",
     ":widenPeerDependencies"
   ],
-  "minimumReleaseAge": "12 days",
   "npmrcMerge": true,
   "packageRules": [
+    {
+      "internalChecksFilter": "strict",
+      "matchDatasources": [
+        "npm"
+      ],
+      "minimumReleaseAge": "12 days"
+    },
     {
       "matchCategories": [
         "js"


### PR DESCRIPTION
We've noticed that renovate still uses `minimumReleaseAge: "3 days"` instead of `"12 days"`. This is related due to the preset `security:minimumReleaseAgeNpm` which we inherit transitively via `config:best-practices`. This preset sets:

```json
{
  "packageRules": [
    {
      "internalChecksFilter": "strict",
      "matchDatasources": [
        "npm"
      ],
      "minimumReleaseAge": "3 days"
    },
    ...
  ]
}
```

Package rules have higher precedence than a config on the root level.