### PR TITLE
fix(base/javascript): rangeStrategy for peerDependencies

### DIFF
--- a/base/javascript.json
+++ b/base/javascript.json
@@ -51,7 +51,8 @@
         "js"
       ],
       "matchDepTypes": [
-        "engines"
+        "engines",
+        "peerDependencies"
       ],
       "rangeStrategy": "auto"
     },

--- a/base/javascript.json
+++ b/base/javascript.json
@@ -44,6 +44,9 @@
       "matchPackageNames": [
         "*"
       ],
+      "matchDepTypes": [
+        "!peerDependencies"
+      ],
       "rangeStrategy": "bump"
     },
     {
@@ -51,8 +54,7 @@
         "js"
       ],
       "matchDepTypes": [
-        "engines",
-        "peerDependencies"
+        "engines"
       ],
       "rangeStrategy": "auto"
     },

--- a/base/javascript.json
+++ b/base/javascript.json
@@ -44,9 +44,6 @@
       "matchPackageNames": [
         "*"
       ],
-      "matchDepTypes": [
-        "!peerDependencies"
-      ],
       "rangeStrategy": "bump"
     },
     {
@@ -72,6 +69,12 @@
       "matchCurrentVersion": "!/^0/",
       "groupName": "all non-major dependencies with stable versions",
       "groupSlug": "all-stable"
+    },
+    {
+      "matchDepTypes": [
+        "peerDependencies"
+      ],
+      "rangeStrategy": "widen"
     }
   ]
 }


### PR DESCRIPTION
Currently `peerDependencies` follow the same `rangeStrategy` as the other types of dependencies. I think `bump` is not a good strategy for `peerDependencies`. In order to avoid bumping `peerDependencies` like in https://github.com/Kong/public-ui-components/pull/3176 which easily could lead to conflicts (check https://github.com/Kong/public-ui-components/pull/3198) I think we should rather use the default (`auto`) behaviour of renovate for `peerDependencies`.

https://docs.renovatebot.com/configuration-options/#rangestrategy
> Renovate's "auto" strategy works like this for npm:
>
> 1. Widen `peerDependencies`

Using `widen` as the `rangeStrategy` for `peerDependencies` avoids enforcing version upgrades on dependents, which in my opinion should be the default strategy for libraries. If not widening a `peerDependencies` this could be interpreted as a breaking change in the library at least when it comes to major versions and therefore mean a major version bump.

---

~I've simply added `peerDependencies` to the already existing setting for `rangeStrategy: "auto"`. If you prefer to have this separate and more explicit I can add it as a separate package rule and/or also explicitly set it to `widen` and not `auto`.~
I've just realized that we use the preset `:widenPeerDependencies` already, which gets superseded by the packageRule:

```json
{
  "matchCategories": [
    "js"
  ],
  "matchPackageNames": [
    "*"
  ],
  "rangeStrategy": "bump"
},
```

Therefore I've added the field `matchDepTypes` to exclude `peerDependencies` from this package rule, which then ensures that the preset is taken into account.