### PR TITLE
feat(frontend): only pin devDependencies

### DIFF
--- a/scoped/frontend/base.json
+++ b/scoped/frontend/base.json
@@ -12,6 +12,7 @@
     "Kong/public-shared-renovate//security/base",
     ":automergeMinor",
     ":automergePatch",
+    ":pinOnlyDevDependencies",
     ":labels(dependencies,renovate-bot)",
     ":noUnscheduledUpdates",
     ":timezone(America/New_York)",


### PR DESCRIPTION
Utilize `pinonlydevdependencies` setting so that `devDependencies` are pinned, `peerDependencies` are widened`, and direct dependencies are pinned https://docs.renovatebot.com/presets-default/#pinonlydevdependencies